### PR TITLE
Fix for creating own values in async input fields

### DIFF
--- a/src/AsyncSelectField.tsx
+++ b/src/AsyncSelectField.tsx
@@ -1,0 +1,83 @@
+import {AsyncSelect, AsyncSelectProps, SegmentAsync} from "@grafana/ui";
+import React, {useEffect, useState} from "react";
+import {SelectableValue} from "@grafana/data";
+
+interface AsyncSelectFieldProps extends AsyncSelectProps<any>{
+    loadOptions: (query?: (string | undefined)) => Promise<Array<SelectableValue<any>>>
+    onChange: (item: SelectableValue<any>) => void
+}
+
+export function AsyncSelectField(props: AsyncSelectFieldProps) {
+    const [isSelected, setIsSelected] = useState<boolean>(false);
+    const [loadChache, setLoadChache] = useState<SelectableValue<any>[] | PromiseLike<SelectableValue<any>[]>>([]);
+
+    useEffect(() => {
+        const fetchOptions = async () => {
+            const result = await props.loadOptions();
+            setLoadChache(result);
+        };
+
+        fetchOptions();
+    }, []);
+
+    const getOptions = (): void | Promise<SelectableValue<any>[]> => {
+        return new Promise(resolve => {
+            resolve(loadChache);
+        });
+    }
+
+    const component = (): React.ReactNode => {
+        if (isSelected) {
+            return (
+                <AsyncSelect
+                    onChange={props.onChange}
+                    value={props.value}
+                    loadOptions={getOptions}
+                    defaultOptions={true}
+                    filterOption={
+                        (option, searchQuery) => {
+                            const label = option?.label ?? '';
+                            if (typeof label === 'string' && label && searchQuery) {
+                                return label.toLowerCase().includes(searchQuery.toLowerCase());
+                            }
+                            return true;
+                        }}
+                    allowCustomValue={true}
+                    createOptionPosition="first"
+                    allowCreateWhileLoading={true}
+                    onCreateOption={props.onCreateOption}
+                    disabled={false}
+                    isClearable={false}
+                    onBlur={() => setIsSelected(false)}
+                    autoFocus={true}
+                    isOpen={true}
+                    onCloseMenu={() => setIsSelected(false)}
+                    width={"auto"}
+                />
+            )
+        } else {
+            return (
+                <SegmentAsync
+                    value={props.value}
+                    loadOptions={() => {
+                        console.log("Dummy options loaded")
+                        return Promise.resolve([]);
+                    }}
+                    onChange={props.onChange}
+                    inputMinWidth={250}
+                    noOptionMessageHandler={() => ''}
+                    onFocus={() => {
+                        setIsSelected(true);
+                        console.log("Focus lost");
+                    }}
+                />
+            )
+        }
+    }
+
+    return (
+            <div>
+                {component()}
+            </div>
+    )
+}

--- a/src/QueryEditor.tsx
+++ b/src/QueryEditor.tsx
@@ -6,6 +6,7 @@ import { QueryEditorProps, SelectableValue } from '@grafana/data';
 import { getTemplateSrv } from '@grafana/runtime';
 import { DataSource } from './datasource';
 import { ThrukDataSourceOptions, ThrukQuery, defaultQuery } from './types';
+import {AsyncSelectField} from "./AsyncSelectField";
 
 type Props = QueryEditorProps<DataSource, ThrukQuery, ThrukDataSourceOptions>;
 
@@ -166,23 +167,20 @@ export const QueryEditor = (props: Props) => {
         <SegmentSection label="FROM">
           <></>
         </SegmentSection>
-        <SegmentAsync
-          onFocus={(e) => {
-            makeInputEditable(props.query.table, e.target as HTMLInputElement);
-          }}
-          value={toSelectableValue(props.query.table || '/')}
-          loadOptions={(filter?: string): Promise<SelectableValue[]> => {
-            return loadTables(filter).then((data) => {
-              makeInputEditable(props.query.table);
-              return data;
-            });
-          }}
-          onChange={(v) => {
-            onValueChange('table', v.value);
-          }}
-          allowCustomValue
-          inputMinWidth={250}
-          noOptionMessageHandler={() => ''}
+        <AsyncSelectField
+            value={toSelectableValue(props.query.table || '/')}
+            loadOptions={(filter?: string): Promise<SelectableValue[]> => {
+              console.log("options loaded");
+
+              return loadTables(filter).then((data) => {
+                makeInputEditable(props.query.table);
+                return data;
+              });
+            }}
+            onChange={(v) => {
+              onValueChange('table', v.value);
+            }}
+            onCreateOption={(customValue) => onValueChange('table', customValue)}
         />
         <InlineField grow>
           <InlineLabel> </InlineLabel>
@@ -206,12 +204,9 @@ export const QueryEditor = (props: Props) => {
                         style={getItemStyle(snapshot.isDragging, provided.draggableProps.style)}
                       >
                         <InlineLabel width={'auto'} className="thruk-dnd-label">
-                          <SegmentAsync
+                          <AsyncSelectField
                             key={props.query.table}
                             value={toSelectableValue(sel || '*')}
-                            onFocus={(e) => {
-                              makeInputEditable(sel, e.target as HTMLInputElement);
-                            }}
                             loadOptions={(filter?: string): Promise<SelectableValue[]> => {
                               if (sel === '*') {
                                 return loadColumns();
@@ -242,8 +237,6 @@ export const QueryEditor = (props: Props) => {
                               props.onChange(props.query);
                               debouncedRunQuery();
                             }}
-                            allowCustomValue
-                            inputMinWidth={180}
                           />
                         </InlineLabel>
                       </div>
@@ -255,7 +248,7 @@ export const QueryEditor = (props: Props) => {
             )}
           </Droppable>
         </DragDropContext>
-        <SegmentAsync
+        <AsyncSelectField
           value={toSelectableValue('+')}
           loadOptions={loadColumns}
           onChange={(v) => {
@@ -268,8 +261,6 @@ export const QueryEditor = (props: Props) => {
             props.onChange(props.query);
             debouncedRunQuery();
           }}
-          allowCustomValue
-          inputMinWidth={180}
         />
         <InlineField grow>
           <InlineLabel> </InlineLabel>


### PR DESCRIPTION
Created a new component that fixes the wrong order for creating a new option in input fields. Hitting enter now creates the desired option instead of selecting a pre-loaded option at the top of the list. 

Loading and caching the available options allows for a quicker retrieval and selection.